### PR TITLE
remove slf4j log binding dep from hadoop-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>hadoop-client</artifactId>
             <version>2.0.0-cdh4.0.1</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
       
         <dependency>


### PR DESCRIPTION
hadoop-client pulls in an additional log4j binding. this triggers a
warning when a project already has a logger and uses hbridge

This is part of my ongoing efforts to cleanup our log handling. In some cases this can help contribute to logging failures.
