### PR TITLE
readd missing optimized HBridge.get() implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "org.cphylabs"
 
 name := "hbridge"
 
-version := "1.0.0-SNAPSHOT"
+version := "1.1.8-SNAPSHOT"
 
 scalaVersion := "2.10.0"
 

--- a/src/main/scala/org/cphylabs/HBridge.scala
+++ b/src/main/scala/org/cphylabs/HBridge.scala
@@ -487,7 +487,9 @@ class HBridge(htablePool: Option[HTablePool], tableName: String) extends Logging
   }
 
   def get(row: Any, family: Any, qualifier: Any): Array[Byte] = {
-    val result = table.get(new Get(HBridge.toBytes(row)))
+    val get = new Get(HBridge.toBytes(row))
+    get.addColumn(HBridge.toBytes(family), HBridge.toBytes(qualifier))
+    val result = table.get(get)
     result.getValue(HBridge.toBytes(family), HBridge.toBytes(qualifier))
   }
 


### PR DESCRIPTION
this was an optimzation that existed in the 1.1.6.1 release, but does not
exist in the current release.
